### PR TITLE
Fix namespace bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/fuelviews/laravel-parameter-tagging.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-parameter-tagging)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/fuelviews/laravel-robots-txt/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/fuelviews/laravel-parameter-tagging/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/fuelviews/laravel-parameter-tagging/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/fuelviews/laravel-parameter-tagging/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/fuelviews/laravel-parameter-tagging.svg?style=flat-square)](https://packagist.org/packages/fuelviews/laravel-parameter-tagging)
 
 
@@ -10,15 +9,13 @@ This package provides middleware for handling `gclid` and `utm` query parameters
 
 ## Installation
 
-### Step 1: Install via Composer
-
 You can install the package via Composer:
 
 ```bash
 composer require fuelviews/laravel-parameter-tagging
 ```
 
-#### Step 2: Register Middleware
+### Register Middleware
 
 Register middleware in your app/Http/Kernel.php file.
 
@@ -37,3 +34,35 @@ Register middleware in your app/Http/Kernel.php file.
         ],
     ];
 ```
+
+## Testing
+
+```bash
+composer test
+```
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+## Security Vulnerabilities
+
+Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
+
+## Credits
+
+- [Thejmitchener](https://github.com/thejmitchener)
+- [Fuelviews](https://github.com/fuelviews)
+- [All Contributors](../../contributors)
+
+## Support us
+
+Fuelviews is a web development agency based in Portland, Maine. You'll find an overview of all our projects [on our website](https://fuelviews.com).
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/src/Http/Middleware/HandleGclid.php
+++ b/src/Http/Middleware/HandleGclid.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\ParameterTagging\Middleware;
+namespace Fuelviews\ParameterTagging\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;

--- a/src/Http/Middleware/HandleUtm.php
+++ b/src/Http/Middleware/HandleUtm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fuelviews\ParameterTagging\Middleware;
+namespace Fuelviews\ParameterTagging\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;


### PR DESCRIPTION
Fixes a namespace bug in the project by updating the namespaces in the `HandleGclid.php` and `HandleUtm.php` files from `Fuelviews\ParameterTagging\Middleware` to `Fuelviews\ParameterTagging\Http\Middleware`. This correction ensures that the middleware classes are properly located within the project structure.

By addressing this namespace bug, the project's functionality is maintained and prevents potential issues related to class loading and autoloading. The updated namespaces align with Laravel conventions and enhance the project's overall code organization.

This change is crucial for the project's stability and maintainability, ensuring that the middleware classes are correctly mapped within the project's namespace structure.